### PR TITLE
fix(markdown): strip style tags when converting html to markdown

### DIFF
--- a/app/utils/markdown.py
+++ b/app/utils/markdown.py
@@ -55,12 +55,15 @@ class TelegramMarkdownConverter(MarkdownConverter):
             convert_as_inline=convert_as_inline
         )
 
+    def convert_style(self, el, text, convert_as_inline):
+        return ''
+
 def generate(html, **options):
     """Convert function with options predefined"""
 
     result = TelegramMarkdownConverter(
         **options,
-        convert=['br', 'p', 'img', 'code', 'pre', 'ul', 'ol', 'li', 'a', 'sup', 'sub'],
+        convert=['br', 'p', 'img', 'code', 'pre', 'ul', 'ol', 'li', 'a', 'sup', 'sub', 'style'],
         bullets='•••'
     ).convert(html).strip()
 


### PR DESCRIPTION
<!-- Please fill in below sections, include details as much as possible -->
<!-- Leave "N/A" to any non-applicable sections instead of leaving them blank -->

## Description
<!---- Describe your changes in detail ---->
Handle `<style>` tags found in Leetcode's API response.
Fixes #4. 

## How has this been tested?
<!---- Please describe in detail how you tested your changes ---->
Mocked the API response and send sample message using Telegram bot.

## Types of changes
<!---- Put an `x` in the box that apply ---->
- [ ] New feature - `feat`
- [x] Bug fix - `fix`
- [ ] Refactor - `refactor`
- [ ] Test cases - `test`
- [ ] Other(s): <!-- Fill the type of changes here -->

## Remarks
<!---- Leave your remarks if applicable ---->
N/A
