### PR TITLE
fix(markdown): disable auto links when converting to markdown

### DIFF
--- a/app/utils/markdown.py
+++ b/app/utils/markdown.py
@@ -63,6 +63,7 @@ def generate(html, **options):
 
     result = TelegramMarkdownConverter(
         **options,
+        autolinks=False,
         convert=['br', 'p', 'img', 'code', 'pre', 'ul', 'ol', 'li', 'a', 'sup', 'sub', 'style'],
         bullets='•••'
     ).convert(html).strip()


### PR DESCRIPTION
This fixes issues which causes extra < and > wrapped around hyperlink with contents matches its href.

<!-- Please fill in below sections, include details as much as possible -->
<!-- Leave "N/A" to any non-applicable sections instead of leaving them blank -->

## Description
<!---- Describe your changes in detail ---->
Disable auto links in `markdownify`, which according to the documentation, it handles `a` tag which its contents match its href specially by default.

For example `<a href="https://leetcode.com/problems/smallest-subtree-with-all-the-deepest-nodes/" target="_blank">https://leetcode.com/problems/smallest-subtree-with-all-the-deepest-nodes/</a>` was converted to `<https://leetcode.com/problems/smallest-subtree-with-all-the-deepest-nodes/>`, which results in extra `<` and `>` found around hyperlink described in #5.

Fix #5.

## How has this been tested?
<!---- Please describe in detail how you tested your changes ---->
Mock API response and send sample message using Telegram bot.

## Types of changes
<!---- Put an `x` in the box that apply ---->
- [ ] New feature - `feat`
- [x] Bug fix - `fix`
- [ ] Refactor - `refactor`
- [ ] Test cases - `test`
- [ ] Other(s): <!-- Fill the type of changes here -->

## Remarks
<!---- Leave your remarks if applicable ---->
N/A
